### PR TITLE
login should fail with an empty api key

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ pipeline {
       steps {
         unstash('dist')
         sh '''
+            cp /etc/ssl/certs/ca-certificates.crt ca-certificates.crt
             docker build -t slickqa/slick -t slickqa/slick:5 -t slickqa/slick:5.0 -t slickqa/slick:5.0.0 -t slickqa/slick:5.0.0.${BUILD_NUMBER} .
             docker push slickqa/slick
             docker rmi slickqa/slick:latest slickqa/slick:5 slickqa/slick:5.0 slickqa/slick:5.0.0 slickqa/slick:5.0.0.${BUILD_NUMBER}

--- a/services/authImpl.go
+++ b/services/authImpl.go
@@ -41,6 +41,9 @@ func (s *SlickAuthService) RefreshToken(ctx context.Context, request *slickqa.Re
 }
 
 func (s *SlickAuthService) LoginWithToken(ctx context.Context, req *slickqa.ApiTokenLoginRequest) (*slickqa.LoginResponse, error) {
+	if req.Token == "" {
+		return failedLoginResponse()
+	}
 	user, err := db.User.FindByToken(req.Token)
 	if err != nil {
 		return failedLoginResponse()


### PR DESCRIPTION
Currently an empty api key is valid, this should not be the case.